### PR TITLE
Store course program id

### DIFF
--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -15,7 +15,7 @@ class CourseController extends Controller
      */
     public function index(Request $request)
     {
-        $query = Course::with('facilitator');
+        $query = Course::with(['facilitator', 'program']);
 
         // Filtros
         if ($request->has('search')) {
@@ -54,8 +54,7 @@ class CourseController extends Controller
             'schedule' => 'required|string|max:255',
             'duration' => 'required|string|max:100',
             'facilitator_id' => 'nullable|exists:users,id',
-            'carrera' => 'nullable|string|max:255', // Si es string
-            // 'carrera' => 'nullable|exists:programas,id', // Si es id de programa
+            'carrera' => 'nullable|exists:tb_programas,id',
         ]);
 
         if ($validator->fails()) {
@@ -72,7 +71,7 @@ class CourseController extends Controller
      */
     public function show(string $id)
     {
-        $course = Course::with('facilitator')->findOrFail($id);
+        $course = Course::with(['facilitator', 'program'])->findOrFail($id);
         return response()->json($course);
     }
 
@@ -94,8 +93,7 @@ class CourseController extends Controller
             'duration' => 'sometimes|required|string|max:100',
             'facilitator_id' => 'nullable|exists:users,id',
             'status' => 'sometimes|in:draft,approved,synced',
-            'carrera' => 'nullable|string|max:255', // Si es string
-            // 'carrera' => 'nullable|exists:programas,id', // Si es id de programa
+            'carrera' => 'nullable|exists:tb_programas,id',
         ]);
 
         if ($validator->fails()) {

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Models\Programa;
 
 class Course extends Model
 {
@@ -34,6 +35,12 @@ class Course extends Model
     public function facilitator()
     {
         return $this->belongsTo(User::class, 'facilitator_id');
+    }
+
+    // Relación con el programa al que pertenece el curso
+    public function program()
+    {
+        return $this->belongsTo(Programa::class, 'carrera');
     }
 
     public function prospectos()

--- a/database/migrations/2025_06_24_232609_add_carrera_to_courses_table.php
+++ b/database/migrations/2025_06_24_232609_add_carrera_to_courses_table.php
@@ -12,7 +12,8 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('courses', function (Blueprint $table) {
-            $table->string('carrera')->nullable()->after('duration');
+            $table->unsignedBigInteger('carrera')->nullable()->after('duration');
+            $table->foreign('carrera')->references('id')->on('tb_programas')->onDelete('set null');
         });
     }
 
@@ -22,6 +23,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('courses', function (Blueprint $table) {
+            $table->dropForeign(['carrera']);
             $table->dropColumn('carrera');
         });
     }


### PR DESCRIPTION
## Summary
- add Program relation to Course
- eager load Program data when listing or showing courses
- validate `carrera` as program id
- link courses to programs via migration

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860137997748328add865068ee2b775