### PR TITLE
Fix document download route

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -329,7 +329,8 @@ Route::prefix('documentos')->group(function () {
     Route::put('/{id}', [ProspectosDocumentoController::class, 'update']);
     Route::delete('/{id}', [ProspectosDocumentoController::class, 'destroy']);
     // routes/api.php
-    Route::get('/documentos/{id}/file', [ProspectosDocumentoController::class, 'download']);
+    // Endpoint para descargar el archivo asociado a un documento
+    Route::get('/{id}/file', [ProspectosDocumentoController::class, 'download']);
 
     Route::get('/prospecto/{prospectoId}', [ProspectosDocumentoController::class, 'documentosPorProspecto']);
 


### PR DESCRIPTION
## Summary
- fix path for document download route

## Testing
- `php vendor/bin/phpunit --version` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6861c0cc16908328ae7bfdcac49b553f