### PR TITLE
Fix bulk delete FK issue and add enrolled students endpoint

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -96,6 +96,8 @@ Route::middleware('auth:sanctum')->group(function () {
 
         Route::get('pendientes-con-docs', [ProspectoController::class, 'pendientesConDocs']);
         Route::get('prospectos/{id}/download-contrato', [ProspectoController::class, 'downloadContrato']);
+        // Prospectos inscritos con sus programas y cursos
+        Route::get('inscritos-with-courses', [ProspectoController::class, 'inscritosConCursos']);
     });
 
     // Importación de prospectos


### PR DESCRIPTION
## Summary
- fix deletion of documents to avoid foreign key violations
- add new `inscritosConCursos` endpoint to list enrolled students with their programs and courses

## Testing
- `php artisan test` *(fails: `bash: php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862b09cd1b88328ab97d1643680027c