### PR TITLE
Fix course assignment routes and add unassign method

### DIFF
--- a/app/Http/Controllers/Api/CourseController.php
+++ b/app/Http/Controllers/Api/CourseController.php
@@ -199,4 +199,24 @@ class CourseController extends Controller
 
         return response()->json(['message' => 'Cursos asignados correctamente']);
     }
+
+    /**
+     * Bulk unassign courses from prospectos
+     */
+    public function unassignCourses(Request $request)
+    {
+        $payload = $request->validate([
+            'prospecto_ids'   => 'required|array',
+            'prospecto_ids.*' => 'exists:prospectos,id',
+            'course_ids'      => 'required|array',
+            'course_ids.*'    => 'exists:courses,id',
+        ]);
+
+        foreach ($payload['prospecto_ids'] as $prospectoId) {
+            $prospecto = Prospecto::findOrFail($prospectoId);
+            $prospecto->courses()->detach($payload['course_ids']);
+        }
+
+        return response()->json(['message' => 'Cursos desasignados correctamente']);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -415,7 +415,7 @@ Route::prefix('courses')->group(function () {
     Route::post('/{course}/sync-moodle', [CourseController::class, 'syncToMoodle']);
     Route::post('/{course}/assign-facilitator', [CourseController::class, 'assignFacilitator']);
 
-    //Rutas de Asignaciond e Cursos
-    Route::post('/courses/assign', [CourseController::class, 'assignCourses']);
-    Route::post('/courses/unassign', [CourseController::class, 'unassignCourses']);
+    // Rutas de asignación de cursos a prospectos
+    Route::post('/assign', [CourseController::class, 'assignCourses']);
+    Route::post('/unassign', [CourseController::class, 'unassignCourses']);
 });


### PR DESCRIPTION
## Summary
- fix duplicate `/courses` prefix on assignment routes
- implement `unassignCourses` method on `CourseController`

## Testing
- `npm test` *(fails: missing script)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c4783150832880ea257530654c58