### PR TITLE
Add academic ranking and GPA features

### DIFF
--- a/app/Http/Controllers/Api/CoursePerformanceController.php
+++ b/app/Http/Controllers/Api/CoursePerformanceController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\CoursePerfResource;
+use App\Models\Course;
+use Illuminate\Http\Request;
+
+class CoursePerformanceController extends Controller
+{
+    public function index(Request $request)
+    {
+        $threshold = $request->input('threshold', 61);
+
+        $query = Course::select('courses.*')
+            ->leftJoin('inscripciones', 'courses.id', '=', 'inscripciones.course_id')
+            ->when($request->periodo, fn($q) => $q->where('inscripciones.semestre', $request->periodo))
+            ->groupBy('courses.id');
+
+        $query->selectRaw('AVG(inscripciones.calificacion) as promedio');
+        $query->selectRaw('SUM(CASE WHEN inscripciones.calificacion >= ? THEN 1 ELSE 0 END)/NULLIF(COUNT(inscripciones.id),0) as tasa_aprobacion', [$threshold]);
+
+        $perPage   = $request->input('per_page', 15);
+        $sortBy    = $request->input('sort_by', 'promedio');
+        $direction = $request->input('direction', 'desc');
+
+        $courses = $query->orderBy($sortBy, $direction)->paginate($perPage);
+
+        return CoursePerfResource::collection($courses);
+    }
+}

--- a/app/Http/Controllers/Api/RankingController.php
+++ b/app/Http/Controllers/Api/RankingController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\RankingResource;
+use App\Models\Prospecto;
+use Illuminate\Http\Request;
+
+class RankingController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Prospecto::select('prospectos.*')
+            ->join('inscripciones', 'prospectos.id', '=', 'inscripciones.prospecto_id')
+            ->leftJoin('estudiante_programa as ep', 'ep.prospecto_id', '=', 'prospectos.id')
+            ->leftJoin('tb_programas as p', 'p.id', '=', 'ep.programa_id')
+            ->when($request->semestre, fn($q) => $q->where('inscripciones.semestre', $request->semestre))
+            ->groupBy('prospectos.id', 'p.total_cursos');
+
+        $query->selectRaw('SUM(inscripciones.calificacion * inscripciones.credits)/NULLIF(SUM(inscripciones.credits),0) as gpa_actual');
+        $query->selectRaw('SUM(inscripciones.credits)/NULLIF(p.total_cursos,0)*100 as progreso');
+
+        if ($request->filled('gpa_min')) {
+            $query->having('gpa_actual', '>=', $request->gpa_min);
+        }
+        if ($request->filled('gpa_max')) {
+            $query->having('gpa_actual', '<=', $request->gpa_max);
+        }
+
+        $sortBy    = $request->input('sort_by', 'gpa_actual');
+        $direction = $request->input('direction', 'desc');
+        $perPage   = $request->input('per_page', 15);
+
+        $ranked = $query->orderBy($sortBy, $direction)->paginate($perPage);
+
+        return RankingResource::collection($ranked);
+    }
+}

--- a/app/Http/Controllers/Api/StudentController.php
+++ b/app/Http/Controllers/Api/StudentController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\StudentResource;
+use App\Models\Prospecto;
+
+class StudentController extends Controller
+{
+    public function show($id)
+    {
+        $prospecto = Prospecto::with([
+            'programas.programa',
+            'inscripciones.course',
+            'gpaHist',
+            'achievements'
+        ])->findOrFail($id);
+
+        return new StudentResource($prospecto);
+    }
+}

--- a/app/Http/Resources/CoursePerfResource.php
+++ b/app/Http/Resources/CoursePerfResource.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CoursePerfResource extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'course_id'       => $this->id,
+            'name'            => $this->name,
+            'promedio'        => $this->promedio ? round($this->promedio, 2) : null,
+            'tasa_aprobacion' => $this->tasa_aprobacion ? round($this->tasa_aprobacion * 100, 2) : 0,
+        ];
+    }
+}

--- a/app/Http/Resources/RankingResource.php
+++ b/app/Http/Resources/RankingResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class RankingResource extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'id'       => $this->id,
+            'nombre'   => $this->nombre_completo,
+            'gpa'      => round($this->gpa_actual, 2),
+            'progreso' => $this->progreso ? round($this->progreso, 2) : 0,
+        ];
+    }
+}

--- a/app/Http/Resources/StudentResource.php
+++ b/app/Http/Resources/StudentResource.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class StudentResource extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'id'     => $this->id,
+            'nombre' => $this->nombre_completo,
+            'programas' => $this->programas->map(fn($p) => [
+                'programa'      => optional($p->programa)->nombre_del_programa,
+                'fecha_inicio'  => $p->fecha_inicio,
+                'fecha_fin'     => $p->fecha_fin,
+            ]),
+            'inscripciones' => $this->inscripciones->map(fn($i) => [
+                'course'      => optional($i->course)->name,
+                'semestre'    => $i->semestre,
+                'credits'     => $i->credits,
+                'calificacion'=> $i->calificacion,
+            ]),
+            'gpa_hist' => $this->gpaHist->map(fn($g) => [
+                'semestre' => $g->semestre,
+                'gpa'      => $g->gpa,
+            ]),
+            'achievements' => $this->achievements->map(fn($a) => [
+                'tipo'     => $a->tipo,
+                'semestre' => $a->semestre,
+            ]),
+        ];
+    }
+}

--- a/app/Models/Achievement.php
+++ b/app/Models/Achievement.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Achievement extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'prospecto_id',
+        'tipo',
+        'semestre',
+    ];
+
+    public function prospecto()
+    {
+        return $this->belongsTo(Prospecto::class);
+    }
+}

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -4,6 +4,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Models\Inscripcion;
 
 class Course extends Model
 {
@@ -44,5 +45,10 @@ class Course extends Model
             'course_id',
             'prospecto_id'
         )->withTimestamps();
+    }
+
+    public function inscripciones()
+    {
+        return $this->hasMany(Inscripcion::class);
     }
 }

--- a/app/Models/GpaHist.php
+++ b/app/Models/GpaHist.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class GpaHist extends Model
+{
+    use HasFactory;
+
+    protected $table = 'gpa_hist';
+
+    protected $fillable = [
+        'prospecto_id',
+        'semestre',
+        'gpa',
+    ];
+
+    public function prospecto()
+    {
+        return $this->belongsTo(Prospecto::class);
+    }
+}

--- a/app/Models/Inscripcion.php
+++ b/app/Models/Inscripcion.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Inscripcion extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'prospecto_id',
+        'course_id',
+        'semestre',
+        'credits',
+        'calificacion',
+    ];
+
+    public function prospecto()
+    {
+        return $this->belongsTo(Prospecto::class);
+    }
+
+    public function course()
+    {
+        return $this->belongsTo(Course::class);
+    }
+}

--- a/app/Models/Prospecto.php
+++ b/app/Models/Prospecto.php
@@ -4,6 +4,9 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Inscripcion;
+use App\Models\GpaHist;
+use App\Models\Achievement;
 
 class Prospecto extends Model
 {
@@ -107,7 +110,7 @@ class Prospecto extends Model
         return $this->hasMany(ProspectosDocumento::class, 'prospecto_id');
     }
 
-        public function courses()
+    public function courses()
     {
         return $this->belongsToMany(
             Course::class,
@@ -115,6 +118,21 @@ class Prospecto extends Model
             'prospecto_id',       // FK en la tabla pivote que apunta a prospectos.id
             'course_id'           // FK en la tabla pivote que apunta a courses.id
         )->withTimestamps();
+    }
+
+    public function inscripciones()
+    {
+        return $this->hasMany(Inscripcion::class);
+    }
+
+    public function gpaHist()
+    {
+        return $this->hasMany(GpaHist::class);
+    }
+
+    public function achievements()
+    {
+        return $this->hasMany(Achievement::class);
     }
     
 }

--- a/database/migrations/2025_07_01_000000_create_inscripciones_table.php
+++ b/database/migrations/2025_07_01_000000_create_inscripciones_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('inscripciones', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('prospecto_id')->constrained('prospectos')->cascadeOnDelete();
+            $table->foreignId('course_id')->constrained('courses')->cascadeOnDelete();
+            $table->string('semestre', 10);
+            $table->smallInteger('credits')->default(0);
+            $table->decimal('calificacion', 5, 2)->nullable();
+            $table->timestamps();
+            $table->unique(['prospecto_id','course_id','semestre']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('inscripciones');
+    }
+};

--- a/database/migrations/2025_07_01_000001_create_gpa_hist_table.php
+++ b/database/migrations/2025_07_01_000001_create_gpa_hist_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('gpa_hist', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('prospecto_id')->constrained('prospectos')->cascadeOnDelete();
+            $table->string('semestre', 10);
+            $table->decimal('gpa', 4, 2);
+            $table->timestamps();
+            $table->unique(['prospecto_id','semestre']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('gpa_hist');
+    }
+};

--- a/database/migrations/2025_07_01_000002_create_achievements_table.php
+++ b/database/migrations/2025_07_01_000002_create_achievements_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('achievements', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('prospecto_id')->constrained('prospectos')->cascadeOnDelete();
+            $table->enum('tipo', ['excelencia','mejor_promedio','avance_destacado']);
+            $table->string('semestre', 10)->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('achievements');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,6 +37,9 @@ use App\Http\Controllers\Api\InscripcionPeriodoController;
 use App\Http\Controllers\Api\ApprovalFlowController;
 use App\Http\Controllers\Api\ApprovalStageController;
 use App\Http\Controllers\Api\CourseController;
+use App\Http\Controllers\Api\RankingController;
+use App\Http\Controllers\Api\CoursePerformanceController;
+use App\Http\Controllers\Api\StudentController;
 
 
 /**
@@ -419,3 +422,8 @@ Route::prefix('courses')->group(function () {
     Route::post('/assign', [CourseController::class, 'assignCourses']);
     Route::post('/unassign', [CourseController::class, 'unassignCourses']);
 });
+
+// Ranking y rendimiento
+Route::get('/ranking/students', [RankingController::class, 'index'])->middleware('auth:sanctum');
+Route::get('/ranking/courses', [CoursePerformanceController::class, 'index'])->middleware('auth:sanctum');
+Route::get('/students/{id}', [StudentController::class, 'show'])->middleware('auth:sanctum');

--- a/tests/Feature/RankingEndpointsTest.php
+++ b/tests/Feature/RankingEndpointsTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\{User, Prospecto, Course, Inscripcion};
+
+class RankingEndpointsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['database.default' => 'sqlite']);
+        config(['database.connections.sqlite.database' => ':memory:']);
+    }
+
+    public function test_student_ranking_endpoint()
+    {
+        $user = User::create([
+            'username' => 'u1',
+            'email' => 'u1@example.com',
+            'password_hash' => bcrypt('secret'),
+            'first_name' => 'U',
+            'last_name' => 'One',
+        ]);
+
+        $this->actingAs($user);
+
+        $prospecto = Prospecto::create([
+            'fecha' => now()->toDateString(),
+            'nombre_completo' => 'John Doe',
+            'telefono' => '123',
+            'correo_electronico' => 'john@example.com',
+            'genero' => 'M',
+        ]);
+
+        $course = Course::create([
+            'name' => 'C1',
+            'code' => 'C1',
+            'area' => 'common',
+            'credits' => 3,
+            'start_date' => now()->toDateString(),
+            'end_date' => now()->addMonth()->toDateString(),
+            'schedule' => 'X',
+            'duration' => '1h',
+            'status' => 'draft',
+        ]);
+
+        Inscripcion::create([
+            'prospecto_id' => $prospecto->id,
+            'course_id' => $course->id,
+            'semestre' => '2023-1',
+            'credits' => 3,
+            'calificacion' => 95,
+        ]);
+
+        $response = $this->getJson('/api/ranking/students');
+
+        $response->assertStatus(200)
+                 ->assertJsonStructure([
+                     'data' => [
+                         [
+                             'id',
+                             'nombre',
+                             'gpa',
+                             'progreso',
+                         ]
+                     ]
+                 ]);
+    }
+
+    public function test_course_performance_endpoint()
+    {
+        $user = User::create([
+            'username' => 'u2',
+            'email' => 'u2@example.com',
+            'password_hash' => bcrypt('secret'),
+            'first_name' => 'U',
+            'last_name' => 'Two',
+        ]);
+
+        $this->actingAs($user);
+
+        $prospecto = Prospecto::create([
+            'fecha' => now()->toDateString(),
+            'nombre_completo' => 'Jane Doe',
+            'telefono' => '456',
+            'correo_electronico' => 'jane@example.com',
+            'genero' => 'F',
+        ]);
+
+        $course = Course::create([
+            'name' => 'C2',
+            'code' => 'C2',
+            'area' => 'common',
+            'credits' => 3,
+            'start_date' => now()->toDateString(),
+            'end_date' => now()->addMonth()->toDateString(),
+            'schedule' => 'X',
+            'duration' => '1h',
+            'status' => 'draft',
+        ]);
+
+        Inscripcion::create([
+            'prospecto_id' => $prospecto->id,
+            'course_id' => $course->id,
+            'semestre' => '2023-1',
+            'credits' => 3,
+            'calificacion' => 80,
+        ]);
+
+        $response = $this->getJson('/api/ranking/courses');
+
+        $response->assertStatus(200)
+                 ->assertJsonStructure([
+                     'data' => [
+                         [
+                             'course_id',
+                             'name',
+                             'promedio',
+                             'tasa_aprobacion',
+                         ]
+                     ]
+                 ]);
+    }
+}


### PR DESCRIPTION
## Summary
- create migrations for student course records, GPA history and achievements
- add models and relationships for new tables
- provide API resources for ranking and course performance
- implement controllers for student ranking, course performance and student detail
- expose new authenticated routes for rankings and student info
- cover endpoints with feature tests

## Testing
- `php vendor/bin/phpunit --testdox -q` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ba6ca2b08328871ec2aa6d055895