### PR TITLE
Add finance module skeleton

### DIFF
--- a/app/Http/Controllers/Api/InvoiceController.php
+++ b/app/Http/Controllers/Api/InvoiceController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Invoice;
+use Illuminate\Http\Request;
+
+class InvoiceController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Invoice::with('prospecto');
+
+        if ($request->filled('prospecto_id')) {
+            $query->where('prospecto_id', $request->prospecto_id);
+        }
+        if ($request->filled('status')) {
+            $query->where('status', $request->status);
+        }
+
+        return response()->json(['data' => $query->get()]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'prospecto_id' => 'required|exists:prospectos,id',
+            'amount' => 'required|numeric',
+            'due_date' => 'required|date',
+            'status' => 'required|string',
+            'description' => 'nullable|string',
+        ]);
+
+        $invoice = Invoice::create($data);
+
+        return response()->json(['data' => $invoice], 201);
+    }
+
+    public function update(Request $request, Invoice $invoice)
+    {
+        $data = $request->validate([
+            'amount' => 'sometimes|numeric',
+            'due_date' => 'sometimes|date',
+            'status' => 'sometimes|string',
+            'description' => 'nullable|string',
+        ]);
+
+        $invoice->update($data);
+
+        return response()->json(['data' => $invoice]);
+    }
+
+    public function destroy(Invoice $invoice)
+    {
+        $invoice->delete();
+
+        return response()->json(['message' => 'deleted']);
+    }
+}

--- a/app/Http/Controllers/Api/PaymentController.php
+++ b/app/Http/Controllers/Api/PaymentController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Payment;
+use Illuminate\Http\Request;
+
+class PaymentController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Payment::with(['prospecto', 'invoice']);
+        if ($request->filled('prospecto_id')) {
+            $query->where('prospecto_id', $request->prospecto_id);
+        }
+
+        return response()->json(['data' => $query->get()]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'prospecto_id' => 'required|exists:prospectos,id',
+            'invoice_id' => 'nullable|exists:invoices,id',
+            'amount' => 'required|numeric',
+            'method' => 'required|string',
+            'status' => 'required|string',
+            'paid_at' => 'nullable|date',
+            'reference' => 'nullable|string',
+        ]);
+
+        $payment = Payment::create($data);
+
+        return response()->json(['data' => $payment], 201);
+    }
+}

--- a/app/Models/CollectionLog.php
+++ b/app/Models/CollectionLog.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CollectionLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'prospecto_id',
+        'date',
+        'type',
+        'notes',
+        'agent',
+        'next_contact_at',
+    ];
+
+    protected $casts = [
+        'date' => 'date',
+        'next_contact_at' => 'datetime',
+    ];
+
+    public function prospecto()
+    {
+        return $this->belongsTo(Prospecto::class);
+    }
+}

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Invoice extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'prospecto_id',
+        'amount',
+        'due_date',
+        'status',
+        'description',
+    ];
+
+    protected $casts = [
+        'amount' => 'decimal:2',
+        'due_date' => 'date',
+    ];
+
+    public function prospecto()
+    {
+        return $this->belongsTo(Prospecto::class);
+    }
+
+    public function payments()
+    {
+        return $this->hasMany(Payment::class);
+    }
+}

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Payment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'prospecto_id',
+        'invoice_id',
+        'amount',
+        'method',
+        'status',
+        'paid_at',
+        'reference',
+    ];
+
+    protected $casts = [
+        'amount' => 'decimal:2',
+        'paid_at' => 'datetime',
+    ];
+
+    public function prospecto()
+    {
+        return $this->belongsTo(Prospecto::class);
+    }
+
+    public function invoice()
+    {
+        return $this->belongsTo(Invoice::class);
+    }
+}

--- a/app/Models/PaymentPlan.php
+++ b/app/Models/PaymentPlan.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PaymentPlan extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'prospecto_id',
+        'total_amount',
+        'status',
+    ];
+
+    protected $casts = [
+        'total_amount' => 'decimal:2',
+    ];
+
+    public function prospecto()
+    {
+        return $this->belongsTo(Prospecto::class);
+    }
+
+    public function installments()
+    {
+        return $this->hasMany(PaymentPlanInstallment::class);
+    }
+}

--- a/app/Models/PaymentPlanInstallment.php
+++ b/app/Models/PaymentPlanInstallment.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PaymentPlanInstallment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'payment_plan_id',
+        'due_date',
+        'amount',
+        'status',
+    ];
+
+    protected $casts = [
+        'due_date' => 'date',
+        'amount' => 'decimal:2',
+    ];
+
+    public function paymentPlan()
+    {
+        return $this->belongsTo(PaymentPlan::class);
+    }
+}

--- a/app/Models/PaymentRule.php
+++ b/app/Models/PaymentRule.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PaymentRule extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'due_day',
+        'late_fee_amount',
+        'block_after_months',
+        'send_automatic_reminders',
+        'gateway_config',
+    ];
+
+    protected $casts = [
+        'late_fee_amount' => 'decimal:2',
+        'send_automatic_reminders' => 'boolean',
+        'gateway_config' => 'array',
+    ];
+}

--- a/app/Models/Prospecto.php
+++ b/app/Models/Prospecto.php
@@ -7,6 +7,11 @@ use Illuminate\Database\Eloquent\Model;
 use App\Models\Inscripcion;
 use App\Models\GpaHist;
 use App\Models\Achievement;
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\PaymentPlan;
+use App\Models\CollectionLog;
+use App\Models\ReconciliationRecord;
 
 class Prospecto extends Model
 {
@@ -133,6 +138,46 @@ class Prospecto extends Model
     public function achievements()
     {
         return $this->hasMany(Achievement::class);
+    }
+
+    /** Finanzas */
+    public function invoices()
+    {
+        return $this->hasMany(Invoice::class);
+    }
+
+    public function payments()
+    {
+        return $this->hasMany(Payment::class);
+    }
+
+    public function paymentPlans()
+    {
+        return $this->hasMany(PaymentPlan::class);
+    }
+
+    public function collectionLogs()
+    {
+        return $this->hasMany(CollectionLog::class);
+    }
+
+    public function reconciliationRecords()
+    {
+        return $this->hasMany(ReconciliationRecord::class);
+    }
+
+    public function getBalance(): float
+    {
+        $invoices = $this->invoices()->sum('amount');
+        $payments = $this->payments()->where('status', 'aprobado')->sum('amount');
+        return (float) ($invoices - $payments);
+    }
+
+    public function isBlocked(): bool
+    {
+        return $this->invoices()
+            ->where('status', 'vencido')
+            ->exists();
     }
     
 }

--- a/app/Models/ReconciliationRecord.php
+++ b/app/Models/ReconciliationRecord.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ReconciliationRecord extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'prospecto_id',
+        'bank',
+        'reference',
+        'amount',
+        'date',
+        'auth_number',
+        'status',
+        'uploaded_by',
+    ];
+
+    protected $casts = [
+        'amount' => 'decimal:2',
+        'date' => 'date',
+    ];
+
+    public function prospecto()
+    {
+        return $this->belongsTo(Prospecto::class);
+    }
+
+    public function uploader()
+    {
+        return $this->belongsTo(User::class, 'uploaded_by');
+    }
+}

--- a/database/migrations/2025_07_02_000000_create_invoices_table.php
+++ b/database/migrations/2025_07_02_000000_create_invoices_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('invoices', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('prospecto_id')->constrained('prospectos')->cascadeOnDelete();
+            $table->decimal('amount', 10, 2);
+            $table->date('due_date');
+            $table->string('status');
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('invoices');
+    }
+};

--- a/database/migrations/2025_07_02_000001_create_payments_table.php
+++ b/database/migrations/2025_07_02_000001_create_payments_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('prospecto_id')->constrained('prospectos')->cascadeOnDelete();
+            $table->foreignId('invoice_id')->nullable()->constrained('invoices')->nullOnDelete();
+            $table->decimal('amount', 10, 2);
+            $table->string('method');
+            $table->string('status');
+            $table->timestamp('paid_at')->nullable();
+            $table->string('reference')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payments');
+    }
+};

--- a/database/migrations/2025_07_02_000002_create_payment_plans_table.php
+++ b/database/migrations/2025_07_02_000002_create_payment_plans_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payment_plans', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('prospecto_id')->constrained('prospectos')->cascadeOnDelete();
+            $table->decimal('total_amount', 10, 2);
+            $table->string('status');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payment_plans');
+    }
+};

--- a/database/migrations/2025_07_02_000003_create_payment_plan_installments_table.php
+++ b/database/migrations/2025_07_02_000003_create_payment_plan_installments_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payment_plan_installments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('payment_plan_id')->constrained('payment_plans')->cascadeOnDelete();
+            $table->date('due_date');
+            $table->decimal('amount', 10, 2);
+            $table->string('status');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payment_plan_installments');
+    }
+};

--- a/database/migrations/2025_07_02_000004_create_payment_rules_table.php
+++ b/database/migrations/2025_07_02_000004_create_payment_rules_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payment_rules', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedTinyInteger('due_day');
+            $table->decimal('late_fee_amount', 10, 2)->default(0);
+            $table->unsignedTinyInteger('block_after_months')->default(0);
+            $table->boolean('send_automatic_reminders')->default(false);
+            $table->json('gateway_config')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payment_rules');
+    }
+};

--- a/database/migrations/2025_07_02_000005_create_reconciliation_records_table.php
+++ b/database/migrations/2025_07_02_000005_create_reconciliation_records_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('reconciliation_records', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('prospecto_id')->nullable()->constrained('prospectos')->nullOnDelete();
+            $table->string('bank');
+            $table->string('reference');
+            $table->decimal('amount', 10, 2);
+            $table->date('date');
+            $table->string('auth_number')->nullable();
+            $table->string('status');
+            $table->foreignId('uploaded_by')->constrained('users')->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('reconciliation_records');
+    }
+};

--- a/database/migrations/2025_07_02_000006_create_collection_logs_table.php
+++ b/database/migrations/2025_07_02_000006_create_collection_logs_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('collection_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('prospecto_id')->constrained('prospectos')->cascadeOnDelete();
+            $table->date('date');
+            $table->string('type');
+            $table->text('notes')->nullable();
+            $table->string('agent');
+            $table->dateTime('next_contact_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('collection_logs');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -40,6 +40,8 @@ use App\Http\Controllers\Api\CourseController;
 use App\Http\Controllers\Api\RankingController;
 use App\Http\Controllers\Api\CoursePerformanceController;
 use App\Http\Controllers\Api\StudentController;
+use App\Http\Controllers\Api\InvoiceController;
+use App\Http\Controllers\Api\PaymentController;
 
 
 /**
@@ -427,3 +429,16 @@ Route::prefix('courses')->group(function () {
 Route::get('/ranking/students', [RankingController::class, 'index'])->middleware('auth:sanctum');
 Route::get('/ranking/courses', [CoursePerformanceController::class, 'index'])->middleware('auth:sanctum');
 Route::get('/students/{id}', [StudentController::class, 'show'])->middleware('auth:sanctum');
+
+// ----------------------
+// Finanzas y Pagos
+// ----------------------
+Route::middleware('auth:sanctum')->group(function () {
+    Route::get('/invoices', [InvoiceController::class, 'index']);
+    Route::post('/invoices', [InvoiceController::class, 'store']);
+    Route::put('/invoices/{invoice}', [InvoiceController::class, 'update']);
+    Route::delete('/invoices/{invoice}', [InvoiceController::class, 'destroy']);
+
+    Route::get('/payments', [PaymentController::class, 'index']);
+    Route::post('/payments', [PaymentController::class, 'store']);
+});


### PR DESCRIPTION
## Summary
- implement migrations for invoices, payments, payment plans, rules and more
- add Eloquent models and relations in Prospecto
- create basic controllers for invoices and payments
- register finance routes under API

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686aee5beca0832892e0355cd9705089