### PR TITLE
Add finance form requests and policies

### DIFF
--- a/app/Http/Controllers/Api/InvoiceController.php
+++ b/app/Http/Controllers/Api/InvoiceController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\Invoice;
 use Illuminate\Http\Request;
+use App\Http\Requests\StoreInvoiceRequest;
 
 class InvoiceController extends Controller
 {
@@ -22,17 +23,9 @@ class InvoiceController extends Controller
         return response()->json(['data' => $query->get()]);
     }
 
-    public function store(Request $request)
+    public function store(StoreInvoiceRequest $request)
     {
-        $data = $request->validate([
-            'prospecto_id' => 'required|exists:prospectos,id',
-            'amount' => 'required|numeric',
-            'due_date' => 'required|date',
-            'status' => 'required|string',
-            'description' => 'nullable|string',
-        ]);
-
-        $invoice = Invoice::create($data);
+        $invoice = Invoice::create($request->validated());
 
         return response()->json(['data' => $invoice], 201);
     }

--- a/app/Http/Controllers/Api/PaymentController.php
+++ b/app/Http/Controllers/Api/PaymentController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\KardexPago;
 use App\Models\CuotaProgramaEstudiante;
 use Illuminate\Http\Request;
+use App\Http\Requests\StorePaymentRequest;
 use Illuminate\Support\Facades\Auth;
 
 
@@ -29,18 +30,9 @@ class PaymentController extends Controller
         return response()->json(['data' => $query->get()]);
     }
 
-    public function store(Request $request)
+    public function store(StorePaymentRequest $request)
     {
-        $data = $request->validate([
-
-            'estudiante_programa_id' => 'required|exists:estudiante_programa,id',
-            'cuota_id' => 'nullable|exists:cuotas_programa_estudiante,id',
-            'fecha_pago' => 'required|date',
-            'monto_pagado' => 'required|numeric',
-            'metodo_pago' => 'nullable|string',
-            'observaciones' => 'nullable|string',
-        ]);
-
+        $data = $request->validated();
         $data['created_by'] = Auth::id();
         $payment = KardexPago::create($data);
 

--- a/app/Http/Requests/StoreInvoiceRequest.php
+++ b/app/Http/Requests/StoreInvoiceRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreInvoiceRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'prospecto_id' => 'required|exists:prospectos,id',
+            'amount' => 'required|numeric',
+            'due_date' => 'required|date',
+            'status' => 'required|string',
+            'description' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Http/Requests/StorePaymentRequest.php
+++ b/app/Http/Requests/StorePaymentRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePaymentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'estudiante_programa_id' => 'required|exists:estudiante_programa,id',
+            'cuota_id' => 'nullable|exists:cuotas_programa_estudiante,id',
+            'fecha_pago' => 'required|date',
+            'monto_pagado' => 'required|numeric',
+            'metodo_pago' => 'nullable|string',
+            'observaciones' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Policies/InvoicePolicy.php
+++ b/app/Policies/InvoicePolicy.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Invoice;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class InvoicePolicy
+{
+    use HandlesAuthorization;
+
+    private function hasFinanceAccess(User $user): bool
+    {
+        return in_array(strtoupper($user->rol), ['ADMIN', 'FINANZAS']);
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $this->hasFinanceAccess($user);
+    }
+
+    public function view(User $user, Invoice $invoice): bool
+    {
+        return $this->hasFinanceAccess($user);
+    }
+
+    public function create(User $user): bool
+    {
+        return $this->hasFinanceAccess($user);
+    }
+
+    public function update(User $user, Invoice $invoice): bool
+    {
+        return $this->hasFinanceAccess($user);
+    }
+
+    public function delete(User $user, Invoice $invoice): bool
+    {
+        return $this->hasFinanceAccess($user);
+    }
+}

--- a/app/Policies/PaymentPlanPolicy.php
+++ b/app/Policies/PaymentPlanPolicy.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\PaymentPlan;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class PaymentPlanPolicy
+{
+    use HandlesAuthorization;
+
+    private function hasFinanceAccess(User $user): bool
+    {
+        return in_array(strtoupper($user->rol), ['ADMIN', 'FINANZAS']);
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $this->hasFinanceAccess($user);
+    }
+
+    public function view(User $user, PaymentPlan $paymentPlan): bool
+    {
+        return $this->hasFinanceAccess($user);
+    }
+
+    public function create(User $user): bool
+    {
+        return $this->hasFinanceAccess($user);
+    }
+
+    public function update(User $user, PaymentPlan $paymentPlan): bool
+    {
+        return $this->hasFinanceAccess($user);
+    }
+
+    public function delete(User $user, PaymentPlan $paymentPlan): bool
+    {
+        return $this->hasFinanceAccess($user);
+    }
+}

--- a/app/Policies/PaymentPolicy.php
+++ b/app/Policies/PaymentPolicy.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Payment;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class PaymentPolicy
+{
+    use HandlesAuthorization;
+
+    private function hasFinanceAccess(User $user): bool
+    {
+        return in_array(strtoupper($user->rol), ['ADMIN', 'FINANZAS']);
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $this->hasFinanceAccess($user);
+    }
+
+    public function view(User $user, Payment $payment): bool
+    {
+        return $this->hasFinanceAccess($user);
+    }
+
+    public function create(User $user): bool
+    {
+        return $this->hasFinanceAccess($user);
+    }
+
+    public function update(User $user, Payment $payment): bool
+    {
+        return $this->hasFinanceAccess($user);
+    }
+
+    public function delete(User $user, Payment $payment): bool
+    {
+        return $this->hasFinanceAccess($user);
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,6 +4,12 @@ namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\PaymentPlan;
+use App\Policies\InvoicePolicy;
+use App\Policies\PaymentPolicy;
+use App\Policies\PaymentPlanPolicy;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -13,7 +19,9 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        //
+        Invoice::class => InvoicePolicy::class,
+        Payment::class => PaymentPolicy::class,
+        PaymentPlan::class => PaymentPlanPolicy::class,
     ];
 
     /**


### PR DESCRIPTION
## Summary
- create `StoreInvoiceRequest` and `StorePaymentRequest`
- apply new requests to invoice and payment controllers
- implement finance access policies for Invoice, Payment and PaymentPlan
- register these policies in `AuthServiceProvider`

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b0a2765008328827e660d2e151310