### PR TITLE
Add financial reports controller

### DIFF
--- a/app/Exports/SummaryExport.php
+++ b/app/Exports/SummaryExport.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Exports;
+
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Illuminate\Support\Collection;
+
+class SummaryExport implements FromCollection, WithHeadings
+{
+    protected array $rows;
+
+    public function __construct(array $rows)
+    {
+        $this->rows = $rows;
+    }
+
+    public function collection()
+    {
+        return new Collection($this->rows);
+    }
+
+    public function headings(): array
+    {
+        return ['total_recaudado', 'deuda_vencida'];
+    }
+}

--- a/app/Http/Controllers/Api/ReportsController.php
+++ b/app/Http/Controllers/Api/ReportsController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\KardexPago;
+use App\Models\CuotaProgramaEstudiante;
+use Illuminate\Http\Request;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Maatwebsite\Excel\Facades\Excel;
+use App\Exports\SummaryExport;
+use App\Jobs\ExportReportJob;
+
+class ReportsController extends Controller
+{
+    /**
+     * Return collected totals and overdue debt amounts.
+     */
+    public function summary()
+    {
+        $totalRecaudado = KardexPago::sum('monto_pagado');
+
+        $deudaVencida = CuotaProgramaEstudiante::where('estado', '!=', 'pagado')
+            ->whereDate('fecha_vencimiento', '<', now())
+            ->sum('monto');
+
+        return response()->json([
+            'total_recaudado' => (float) $totalRecaudado,
+            'deuda_vencida'   => (float) $deudaVencida,
+        ]);
+    }
+
+    /**
+     * Export the summary as PDF or Excel. If ?queue=1 is provided the export
+     * will be queued and stored.
+     */
+    public function export(Request $request)
+    {
+        $format = $request->input('format', 'pdf');
+
+        if ($request->boolean('queue')) {
+            ExportReportJob::dispatch($format);
+            return response()->json(['queued' => true]);
+        }
+
+        $data = [
+            'total_recaudado' => KardexPago::sum('monto_pagado'),
+            'deuda_vencida'   => CuotaProgramaEstudiante::where('estado', '!=', 'pagado')
+                ->whereDate('fecha_vencimiento', '<', now())
+                ->sum('monto'),
+        ];
+
+        if ($format === 'excel') {
+            return Excel::download(new SummaryExport([$data]), 'reporte.xlsx');
+        }
+
+        $pdf = Pdf::loadView('pdf.report-summary', $data);
+        return $pdf->download('reporte.pdf');
+    }
+}

--- a/app/Jobs/ExportReportJob.php
+++ b/app/Jobs/ExportReportJob.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Maatwebsite\Excel\Facades\Excel;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Support\Facades\Storage;
+use App\Exports\SummaryExport;
+use App\Models\KardexPago;
+use App\Models\CuotaProgramaEstudiante;
+
+class ExportReportJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected string $format;
+
+    public function __construct(string $format = 'pdf')
+    {
+        $this->format = $format;
+    }
+
+    public function handle(): void
+    {
+        $data = [
+            'total_recaudado' => KardexPago::sum('monto_pagado'),
+            'deuda_vencida'   => CuotaProgramaEstudiante::where('estado', '!=', 'pagado')
+                ->whereDate('fecha_vencimiento', '<', now())
+                ->sum('monto'),
+        ];
+
+        if ($this->format === 'excel') {
+            Excel::store(new SummaryExport([$data]), 'reportes/resumen.xlsx');
+        } else {
+            $pdf = Pdf::loadView('pdf.report-summary', $data);
+            Storage::put('reportes/resumen.pdf', $pdf->output());
+        }
+    }
+}

--- a/resources/views/pdf/report-summary.blade.php
+++ b/resources/views/pdf/report-summary.blade.php
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Resumen Financiero</title>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+        th, td { padding: 8px; border: 1px solid #ccc; text-align: left; }
+    </style>
+</head>
+<body>
+    <h1>Resumen Financiero</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>Total Recaudado</th>
+                <th>Deuda Vencida</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>{{ number_format($total_recaudado, 2) }}</td>
+                <td>{{ number_format($deuda_vencida, 2) }}</td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -42,6 +42,7 @@ use App\Http\Controllers\Api\CoursePerformanceController;
 use App\Http\Controllers\Api\StudentController;
 use App\Http\Controllers\Api\InvoiceController;
 use App\Http\Controllers\Api\PaymentController;
+use App\Http\Controllers\Api\ReportsController;
 
 
 /**
@@ -449,5 +450,8 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::get('/kardex-pagos', [\App\Http\Controllers\Api\KardexPagoController::class, 'index']);
     Route::post('/kardex-pagos', [\App\Http\Controllers\Api\KardexPagoController::class, 'store']);
+
+    Route::get('/reports/summary', [ReportsController::class, 'summary']);
+    Route::get('/reports/export', [ReportsController::class, 'export']);
 
 });


### PR DESCRIPTION
## Summary
- add `ReportsController` with financial summary and export endpoints
- create export class and queued job for exporting
- add minimal PDF view for summary
- register `/api/reports/summary` and `/api/reports/export` routes

## Testing
- `phpunit` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b0a14bf0c8328b887ebb78536f372