### PR TITLE
Implement CollectionLog CRUD

### DIFF
--- a/app/Http/Controllers/Api/CollectionLogController.php
+++ b/app/Http/Controllers/Api/CollectionLogController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\CollectionLog;
+use Illuminate\Http\Request;
+
+class CollectionLogController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request)
+    {
+        $query = CollectionLog::query();
+
+        if ($request->filled('prospecto_id')) {
+            $query->where('prospecto_id', $request->prospecto_id);
+        }
+
+        return response()->json(['data' => $query->get()]);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'prospecto_id'    => 'required|exists:prospectos,id',
+            'date'            => 'required|date',
+            'type'            => 'required|string',
+            'notes'           => 'nullable|string',
+            'agent'           => 'required|string',
+            'next_contact_at' => 'nullable|date',
+        ]);
+
+        $log = CollectionLog::create($data);
+
+        return response()->json(['data' => $log], 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show($id)
+    {
+        $log = CollectionLog::findOrFail($id);
+        return response()->json(['data' => $log]);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, $id)
+    {
+        $log = CollectionLog::findOrFail($id);
+
+        $data = $request->validate([
+            'prospecto_id'    => 'sometimes|exists:prospectos,id',
+            'date'            => 'sometimes|date',
+            'type'            => 'sometimes|string',
+            'notes'           => 'nullable|string',
+            'agent'           => 'sometimes|string',
+            'next_contact_at' => 'nullable|date',
+        ]);
+
+        $log->update($data);
+
+        return response()->json(['data' => $log]);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy($id)
+    {
+        CollectionLog::findOrFail($id)->delete();
+        return response()->json(null, 204);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -42,6 +42,7 @@ use App\Http\Controllers\Api\CoursePerformanceController;
 use App\Http\Controllers\Api\StudentController;
 use App\Http\Controllers\Api\InvoiceController;
 use App\Http\Controllers\Api\PaymentController;
+use App\Http\Controllers\Api\CollectionLogController;
 
 
 /**
@@ -449,5 +450,12 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::get('/kardex-pagos', [\App\Http\Controllers\Api\KardexPagoController::class, 'index']);
     Route::post('/kardex-pagos', [\App\Http\Controllers\Api\KardexPagoController::class, 'store']);
+
+    // Collection Logs
+    Route::get('/collection-logs', [CollectionLogController::class, 'index']);
+    Route::post('/collection-logs', [CollectionLogController::class, 'store']);
+    Route::get('/collection-logs/{id}', [CollectionLogController::class, 'show']);
+    Route::put('/collection-logs/{id}', [CollectionLogController::class, 'update']);
+    Route::delete('/collection-logs/{id}', [CollectionLogController::class, 'destroy']);
 
 });


### PR DESCRIPTION
## Summary
- add basic CRUD for `CollectionLog`
- allow filtering by `prospecto_id`
- register new API endpoints under `/api/collection-logs`

## Testing
- `vendor/bin/phpunit --testdox` *(fails: Permission denied)*
- `php vendor/bin/phpunit --testdox` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b0a13890c8328b78464ae0abcdbdc