### PR TITLE
Add payment rules API

### DIFF
--- a/app/Http/Controllers/Api/RuleController.php
+++ b/app/Http/Controllers/Api/RuleController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\UpdatePaymentRuleRequest;
+use App\Models\PaymentRule;
+
+class RuleController extends Controller
+{
+    public function index()
+    {
+        return response()->json(PaymentRule::all());
+    }
+
+    public function update(UpdatePaymentRuleRequest $request, PaymentRule $rule)
+    {
+        $rule->update($request->validated());
+        return response()->json($rule);
+    }
+}

--- a/app/Http/Requests/UpdatePaymentRuleRequest.php
+++ b/app/Http/Requests/UpdatePaymentRuleRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdatePaymentRuleRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'due_day' => 'sometimes|integer|between:1,31',
+            'late_fee_amount' => 'sometimes|numeric|min:0',
+            'block_after_months' => 'sometimes|integer|min:0',
+            'send_automatic_reminders' => 'sometimes|boolean',
+            'gateway_config' => 'sometimes|array',
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -42,6 +42,7 @@ use App\Http\Controllers\Api\CoursePerformanceController;
 use App\Http\Controllers\Api\StudentController;
 use App\Http\Controllers\Api\InvoiceController;
 use App\Http\Controllers\Api\PaymentController;
+use App\Http\Controllers\Api\RuleController;
 
 
 /**
@@ -441,6 +442,9 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::get('/payments', [PaymentController::class, 'index']);
     Route::post('/payments', [PaymentController::class, 'store']);
+
+    Route::get('/payment-rules', [RuleController::class, 'index']);
+    Route::put('/payment-rules/{rule}', [RuleController::class, 'update']);
 
 
     // Planes de pago reales


### PR DESCRIPTION
## Summary
- add RuleController with index and update actions
- add UpdatePaymentRuleRequest for validation
- expose routes for payment rules management

## Testing
- `./vendor/bin/phpunit` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_686b0a11e88c8328a4439b53bb551347