### PR TITLE
Add reconciliation controller

### DIFF
--- a/app/Http/Controllers/Api/ReconciliationController.php
+++ b/app/Http/Controllers/Api/ReconciliationController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\ReconciliationRecord;
+use App\Models\Payment;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Maatwebsite\Excel\Facades\Excel;
+use Carbon\Carbon;
+
+class ReconciliationController extends Controller
+{
+    /**
+     * Upload reconciliation file and store records as pending.
+     */
+    public function upload(Request $request)
+    {
+        $request->validate([
+            'file' => 'required|file|mimes:csv,xlsx,xls'
+        ]);
+
+        $userId = Auth::id();
+        $rows = Excel::toCollection(null, $request->file('file'))->first();
+        $count = 0;
+
+        foreach ($rows as $row) {
+            $data = [
+                'bank'        => $row['bank'] ?? $row[0] ?? '',
+                'reference'   => $row['reference'] ?? $row[1] ?? '',
+                'amount'      => $row['amount'] ?? $row[2] ?? 0,
+                'date'        => isset($row['date']) ? Carbon::parse($row['date'])->format('Y-m-d') : (isset($row[3]) ? Carbon::parse($row[3])->format('Y-m-d') : now()->toDateString()),
+                'auth_number' => $row['auth_number'] ?? $row[4] ?? null,
+                'status'      => 'pendiente',
+                'uploaded_by' => $userId,
+            ];
+            ReconciliationRecord::create($data);
+            $count++;
+        }
+
+        return response()->json(['inserted' => $count], 201);
+    }
+
+    /**
+     * List pending reconciliation records.
+     */
+    public function pending()
+    {
+        $records = ReconciliationRecord::where('status', 'pendiente')
+            ->with(['prospecto', 'uploader'])
+            ->get();
+
+        return response()->json(['data' => $records]);
+    }
+
+    /**
+     * Process pending records matching payments by reference and amount.
+     */
+    public function process()
+    {
+        $records = ReconciliationRecord::where('status', 'pendiente')->get();
+        $matched = 0;
+
+        foreach ($records as $rec) {
+            $payment = Payment::where('reference', $rec->reference)
+                ->where('amount', $rec->amount)
+                ->first();
+
+            if ($payment) {
+                $rec->prospecto_id = $payment->prospecto_id;
+                $rec->status = 'conciliado';
+                $rec->save();
+
+                $payment->status = 'conciliado';
+                $payment->save();
+                $matched++;
+            }
+        }
+
+        return response()->json(['matched' => $matched]);
+    }
+}
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -42,6 +42,7 @@ use App\Http\Controllers\Api\CoursePerformanceController;
 use App\Http\Controllers\Api\StudentController;
 use App\Http\Controllers\Api\InvoiceController;
 use App\Http\Controllers\Api\PaymentController;
+use App\Http\Controllers\Api\ReconciliationController;
 
 
 /**
@@ -449,5 +450,8 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::get('/kardex-pagos', [\App\Http\Controllers\Api\KardexPagoController::class, 'index']);
     Route::post('/kardex-pagos', [\App\Http\Controllers\Api\KardexPagoController::class, 'store']);
+    Route::post('/reconciliation/upload', [ReconciliationController::class, 'upload']);
+    Route::get('/reconciliation/pending', [ReconciliationController::class, 'pending']);
+    Route::post('/reconciliation/process', [ReconciliationController::class, 'process']);
 
 });


### PR DESCRIPTION
## Summary
- implement `ReconciliationController` to handle uploading reconciliation files, listing pending records and processing them
- define new API routes for reconciliation endpoints

## Testing
- `php ./vendor/bin/phpunit --stop-on-failure` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686b0a1185108328ae6bf05ae999a421