### PR TITLE
Add payment plan controller and routes

### DIFF
--- a/app/Http/Controllers/Api/PaymentPlanController.php
+++ b/app/Http/Controllers/Api/PaymentPlanController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\PaymentPlan;
+use App\Models\PaymentPlanInstallment;
+use Illuminate\Http\Request;
+
+class PaymentPlanController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = PaymentPlan::with('prospecto');
+
+        if ($request->filled('prospecto_id')) {
+            $query->where('prospecto_id', $request->prospecto_id);
+        }
+
+        return response()->json(['data' => $query->get()]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'prospecto_id' => 'required|exists:prospectos,id',
+            'total_amount' => 'required|numeric',
+            'status'       => 'required|string',
+        ]);
+
+        $plan = PaymentPlan::create($data);
+
+        return response()->json(['data' => $plan], 201);
+    }
+
+    public function show(PaymentPlan $paymentPlan)
+    {
+        $paymentPlan->load('installments');
+        return response()->json(['data' => $paymentPlan]);
+    }
+
+    public function update(Request $request, PaymentPlan $paymentPlan)
+    {
+        $data = $request->validate([
+            'total_amount' => 'sometimes|numeric',
+            'status'       => 'sometimes|string',
+        ]);
+
+        $paymentPlan->update($data);
+
+        return response()->json(['data' => $paymentPlan]);
+    }
+
+    public function destroy(PaymentPlan $paymentPlan)
+    {
+        $paymentPlan->delete();
+
+        return response()->json(['message' => 'deleted']);
+    }
+
+    /* ===== Installments ===== */
+    public function indexInstallments(PaymentPlan $paymentPlan)
+    {
+        return response()->json(['data' => $paymentPlan->installments]);
+    }
+
+    public function storeInstallment(Request $request, PaymentPlan $paymentPlan)
+    {
+        $data = $request->validate([
+            'due_date' => 'required|date',
+            'amount'   => 'required|numeric',
+            'status'   => 'required|string',
+        ]);
+
+        $installment = $paymentPlan->installments()->create($data);
+
+        return response()->json(['data' => $installment], 201);
+    }
+
+    public function showInstallment(PaymentPlanInstallment $installment)
+    {
+        return response()->json(['data' => $installment]);
+    }
+
+    public function updateInstallment(Request $request, PaymentPlanInstallment $installment)
+    {
+        $data = $request->validate([
+            'due_date' => 'sometimes|date',
+            'amount'   => 'sometimes|numeric',
+            'status'   => 'sometimes|string',
+        ]);
+
+        $installment->update($data);
+
+        return response()->json(['data' => $installment]);
+    }
+
+    public function destroyInstallment(PaymentPlanInstallment $installment)
+    {
+        $installment->delete();
+
+        return response()->json(['message' => 'deleted']);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -442,6 +442,20 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/payments', [PaymentController::class, 'index']);
     Route::post('/payments', [PaymentController::class, 'store']);
 
+    Route::prefix('payment-plans')->group(function () {
+        Route::get('/', [\App\Http\Controllers\Api\PaymentPlanController::class, 'index']);
+        Route::post('/', [\App\Http\Controllers\Api\PaymentPlanController::class, 'store']);
+        Route::get('/{paymentPlan}', [\App\Http\Controllers\Api\PaymentPlanController::class, 'show']);
+        Route::put('/{paymentPlan}', [\App\Http\Controllers\Api\PaymentPlanController::class, 'update']);
+        Route::delete('/{paymentPlan}', [\App\Http\Controllers\Api\PaymentPlanController::class, 'destroy']);
+
+        Route::get('/{paymentPlan}/installments', [\App\Http\Controllers\Api\PaymentPlanController::class, 'indexInstallments']);
+        Route::post('/{paymentPlan}/installments', [\App\Http\Controllers\Api\PaymentPlanController::class, 'storeInstallment']);
+        Route::get('/installments/{installment}', [\App\Http\Controllers\Api\PaymentPlanController::class, 'showInstallment']);
+        Route::put('/installments/{installment}', [\App\Http\Controllers\Api\PaymentPlanController::class, 'updateInstallment']);
+        Route::delete('/installments/{installment}', [\App\Http\Controllers\Api\PaymentPlanController::class, 'destroyInstallment']);
+    });
+
 
     // Planes de pago reales
     Route::get('/prospectos/{id}/cuotas', [\App\Http\Controllers\Api\CuotaController::class, 'byProspecto']);


### PR DESCRIPTION
## Summary
- implement `PaymentPlanController` with CRUD operations
- support nested installment management
- register new finance routes for payment plans

## Testing
- `php vendor/bin/phpunit` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b0a0ef5b483288e69e5954ac31470