### PR TITLE
Add payment rule notification endpoints

### DIFF
--- a/app/Http/Controllers/Api/PaymentRuleNotificationController.php
+++ b/app/Http/Controllers/Api/PaymentRuleNotificationController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\PaymentRule;
+use App\Models\PaymentRuleNotification;
+use Illuminate\Http\Request;
+
+class PaymentRuleNotificationController extends Controller
+{
+    public function store(Request $request, $ruleId)
+    {
+        $rule = PaymentRule::findOrFail($ruleId);
+
+        $data = $request->validate([
+            'type' => 'nullable|string',
+            'offset_days' => 'required|integer',
+            'message' => 'nullable|string',
+        ]);
+
+        $notification = $rule->notifications()->create($data);
+
+        return response()->json(['data' => $notification], 201);
+    }
+
+    public function update(Request $request, $ruleId, $notificationId)
+    {
+        $rule = PaymentRule::findOrFail($ruleId);
+        $notification = $rule->notifications()->findOrFail($notificationId);
+
+        $data = $request->validate([
+            'type' => 'sometimes|nullable|string',
+            'offset_days' => 'sometimes|integer',
+            'message' => 'nullable|string',
+        ]);
+
+        $notification->update($data);
+
+        return response()->json(['data' => $notification]);
+    }
+
+    public function destroy($ruleId, $notificationId)
+    {
+        $rule = PaymentRule::findOrFail($ruleId);
+        $notification = $rule->notifications()->findOrFail($notificationId);
+        $notification->delete();
+
+        return response()->json(null, 204);
+    }
+}

--- a/app/Models/PaymentRule.php
+++ b/app/Models/PaymentRule.php
@@ -22,4 +22,9 @@ class PaymentRule extends Model
         'send_automatic_reminders' => 'boolean',
         'gateway_config' => 'array',
     ];
+
+    public function notifications()
+    {
+        return $this->hasMany(PaymentRuleNotification::class);
+    }
 }

--- a/app/Models/PaymentRuleNotification.php
+++ b/app/Models/PaymentRuleNotification.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PaymentRuleNotification extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'payment_rule_id',
+        'type',
+        'offset_days',
+        'message',
+    ];
+
+    protected $casts = [
+        'offset_days' => 'integer',
+    ];
+
+    public function rule()
+    {
+        return $this->belongsTo(PaymentRule::class, 'payment_rule_id');
+    }
+}

--- a/database/migrations/2025_07_02_000005_create_payment_rule_notifications_table.php
+++ b/database/migrations/2025_07_02_000005_create_payment_rule_notifications_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payment_rule_notifications', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('payment_rule_id')->constrained('payment_rules')->cascadeOnDelete();
+            $table->string('type')->nullable();
+            $table->integer('offset_days')->default(0);
+            $table->string('message')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payment_rule_notifications');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -23,6 +23,7 @@ class DatabaseSeeder extends Seeder
             ProgramasSeeder::class,
             PrecioProgramasSeeder::class,
             CoursesSeeder::class,
+            RankingDemoSeeder::class,
         ]);
     }
 }

--- a/database/seeders/RankingDemoSeeder.php
+++ b/database/seeders/RankingDemoSeeder.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use App\Models\Prospecto;
+use App\Models\EstudiantePrograma;
+use App\Models\Programa;
+use App\Models\Course;
+use App\Models\Inscripcion;
+use App\Models\GpaHist;
+use App\Models\Achievement;
+
+class RankingDemoSeeder extends Seeder
+{
+    public function run()
+    {
+        DB::transaction(function () {
+            // Ensure two programs exist with total_cursos set
+            $bba = Programa::firstOrCreate(
+                ['abreviatura' => 'BBA'],
+                [
+                    'nombre_del_programa' => 'Bachelor of Business Administration',
+                    'meses' => 32,
+                    'activo' => true,
+                ]
+            );
+            $bba->update(['total_cursos' => 10]);
+
+            $mba = Programa::firstOrCreate(
+                ['abreviatura' => 'MBA'],
+                [
+                    'nombre_del_programa' => 'Master of Business Administration',
+                    'meses' => 21,
+                    'activo' => true,
+                ]
+            );
+            $mba->update(['total_cursos' => 8]);
+
+            // Make sure we have some courses
+            $courses = Course::limit(3)->get();
+            if ($courses->count() === 0) {
+                $coursesData = [
+                    ['code' => 'BBA101', 'name' => 'Introduccion a Administracion'],
+                    ['code' => 'BBA102', 'name' => 'Contabilidad Basica'],
+                    ['code' => 'MBA201', 'name' => 'Gerencia Estrategica'],
+                ];
+                foreach ($coursesData as $cd) {
+                    $courses[] = Course::updateOrCreate(
+                        ['code' => $cd['code']],
+                        [
+                            'name' => $cd['name'],
+                            'area' => 'common',
+                            'credits' => 3,
+                            'start_date' => now()->toDateString(),
+                            'end_date' => now()->addMonth()->toDateString(),
+                            'schedule' => 'Lun-Vie 08:00-12:00',
+                            'duration' => '4h',
+                            'status' => 'approved',
+                            'students' => 0,
+                        ]
+                    );
+                }
+            }
+
+            $students = [
+                ['nombre' => 'Ana Gomez',  'email' => 'ana@example.com',  'tel' => '555-0001', 'genero' => 'F', 'program' => $bba],
+                ['nombre' => 'Luis Perez', 'email' => 'luis@example.com', 'tel' => '555-0002', 'genero' => 'M', 'program' => $bba],
+                ['nombre' => 'Maria Lopez','email' => 'maria@example.com','tel' => '555-0003', 'genero' => 'F', 'program' => $mba],
+            ];
+
+            foreach ($students as $idx => $s) {
+                $prospecto = Prospecto::create([
+                    'fecha' => now()->toDateString(),
+                    'nombre_completo' => $s['nombre'],
+                    'telefono' => $s['tel'],
+                    'correo_electronico' => $s['email'],
+                    'genero' => $s['genero'],
+                ]);
+
+                EstudiantePrograma::create([
+                    'prospecto_id' => $prospecto->id,
+                    'programa_id' => $s['program']->id,
+                    'fecha_inicio' => now()->subMonths(6),
+                    'fecha_fin' => now()->addMonths(6),
+                    'duracion_meses' => $s['program']->meses,
+                    'inscripcion' => 1000,
+                    'cuota_mensual' => 1500,
+                    'inversion_total' => 20000,
+                ]);
+
+                foreach ($courses as $c) {
+                    Inscripcion::create([
+                        'prospecto_id' => $prospecto->id,
+                        'course_id' => $c->id,
+                        'semestre' => '2025A',
+                        'credits' => $c->credits,
+                        'calificacion' => 70 + $idx * 5,
+                    ]);
+                }
+
+                GpaHist::create([
+                    'prospecto_id' => $prospecto->id,
+                    'semestre' => '2025A',
+                    'gpa' => 8.5 - $idx * 0.3,
+                ]);
+
+                Achievement::create([
+                    'prospecto_id' => $prospecto->id,
+                    'tipo' => 'excelencia',
+                    'semestre' => '2025A',
+                ]);
+            }
+        });
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -48,6 +48,7 @@ use App\Http\Controllers\Api\ReconciliationController;
 
 use App\Http\Controllers\Api\RuleController;
 use App\Http\Controllers\Api\CollectionLogController;
+use App\Http\Controllers\Api\PaymentRuleNotificationController;
 
 
 
@@ -467,6 +468,10 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::get('/payment-rules', [RuleController::class, 'index']);
     Route::put('/payment-rules/{rule}', [RuleController::class, 'update']);
+
+    Route::post('/payment-rules/{rule}/notifications', [PaymentRuleNotificationController::class, 'store']);
+    Route::put('/payment-rules/{rule}/notifications/{notification}', [PaymentRuleNotificationController::class, 'update']);
+    Route::delete('/payment-rules/{rule}/notifications/{notification}', [PaymentRuleNotificationController::class, 'destroy']);
 
 
 


### PR DESCRIPTION
## Summary
- create payment_rule_notifications table
- add PaymentRuleNotification model and relationship
- implement PaymentRuleNotificationController
- expose routes for creating, updating and deleting notifications
- add RankingDemoSeeder for ranking and performance endpoints

## Testing
- `vendor/bin/phpunit` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_686bb2eb097083289271ce8de8565ca5