### PR TITLE
Add academic status query

### DIFF
--- a/app/Http/Controllers/Api/MoodleConsultasController.php
+++ b/app/Http/Controllers/Api/MoodleConsultasController.php
@@ -50,5 +50,17 @@ class MoodleConsultasController extends Controller
 
         return response()->json(['data' => $results]);
     }
+
+    public function estatusAcademico(Request $request, $carnet = null)
+    {
+        $carnetInput = $carnet ?? $request->input('carnet');
+        if (!$carnetInput) {
+            return response()->json(['message' => 'El campo carnet es obligatorio'], 422);
+        }
+
+        $result = $this->queries->estatusAcademico($carnetInput);
+
+        return response()->json(['data' => $result]);
+    }
 }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -537,6 +537,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/moodle/consultas/{carnet?}', [MoodleConsultasController::class, 'cursosPorCarnet']);
     Route::get('/moodle/consultas/aprobados/{carnet?}', [MoodleConsultasController::class, 'cursosAprobados']);
     Route::get('/moodle/consultas/reprobados/{carnet?}', [MoodleConsultasController::class, 'cursosReprobados']);
+    Route::get('/moodle/consultas/estatus/{carnet?}', [MoodleConsultasController::class, 'estatusAcademico']);
 
     Route::get('/moodle/consultas', [MoodleConsultasController::class, 'cursosPorCarnet']);
 


### PR DESCRIPTION
## Summary
- extend MoodleQueryService with `estatusAcademico` method to compute detailed academic status from Moodle
- expose `estatusAcademico` endpoint in MoodleConsultasController and routes

## Testing
- `php artisan test` *(fails: Failed opening required ezyang/htmlpurifier)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6890e50777748328aff8c583fb96cea6