### PR TITLE
Fix contract email sending and attachment

### DIFF
--- a/app/Http/Controllers/Api/ProspectoController.php
+++ b/app/Http/Controllers/Api/ProspectoController.php
@@ -452,8 +452,9 @@ class ProspectoController extends Controller
             ]);
             $pdfData = $pdf->output();
 
-            // Enviar correo
+            // Enviar correo al prospecto y en copia al asesor
             Mail::to($prospecto->correo_electronico)
+                ->cc($advisor->email)
                 ->send(new SendContractPdf(
                     $prospecto,
                     $pdfData,
@@ -462,7 +463,8 @@ class ProspectoController extends Controller
                     $estProg->inscripcion,
                     $estProg->cuota_mensual,
                     $estProg->convenio_id,
-                    $advisorName
+                    $advisorName,
+                    $request->signature
                 ));
 
             // ——— Aquí guardamos el registro en contactos_enviados ———

--- a/app/Mail/SendContractPdf.php
+++ b/app/Mail/SendContractPdf.php
@@ -20,6 +20,8 @@ class SendContractPdf extends Mailable
     public $inscripcion;
     public $mensualidad;
     public $convenio_id;
+    public $advisorName;
+    public $signature;
 
     public function __construct(
         $student,
@@ -28,7 +30,9 @@ class SendContractPdf extends Mailable
         $programa,
         $inscripcion,
         $mensualidad,
-        $convenio_id
+        $convenio_id,
+        $advisorName,
+        $signature = null
     ) {
         $this->student     = $student;
         $this->pdfData     = $pdfData;
@@ -37,6 +41,8 @@ class SendContractPdf extends Mailable
         $this->inscripcion = $inscripcion;
         $this->mensualidad = $mensualidad;
         $this->convenio_id = $convenio_id;
+        $this->advisorName = $advisorName;
+        $this->signature   = $signature;
     }
 
     public function envelope(): Envelope
@@ -57,7 +63,8 @@ class SendContractPdf extends Mailable
                 'inscripcion'  => $this->inscripcion,
                 'mensualidad'  => $this->mensualidad,
                 'convenio_id'  => $this->convenio_id,
-                'signature'    => $this->signature ?? null,
+                'signature'    => $this->signature,
+                'advisorName'  => $this->advisorName,
             ]
         );
     }


### PR DESCRIPTION
## Summary
- include advisor name and user signature in contract email view and attachment
- send contract email to prospect and CC advisor

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/ASM_backend-/vendor/composer/../ezyang/htmlpurifier/library/HTMLPurifier.composer.php')*


------
https://chatgpt.com/codex/tasks/task_e_6894261fa3d4832886980470c8ed7bc4