### PR TITLE
Implement role-based permissions with gates and tests

### DIFF
--- a/app/Console/Commands/PermissionsSync.php
+++ b/app/Console/Commands/PermissionsSync.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Database\Seeders\PermissionsSeeder;
+use Database\Seeders\RolePermissionsSeeder;
+
+class PermissionsSync extends Command
+{
+    protected $signature = 'permissions:sync {--seed-roles}';
+
+    protected $description = 'Synchronize permissions with module views';
+
+    public function handle(): int
+    {
+        (new PermissionsSeeder())->run();
+
+        if ($this->option('seed-roles')) {
+            (new RolePermissionsSeeder())->run();
+        }
+
+        $this->info('Permissions synchronized.');
+        return Command::SUCCESS;
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -64,5 +64,6 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'permission' => \App\Http\Middleware\EnsureHasPermission::class,
     ];
 }

--- a/app/Http/Middleware/EnsureHasPermission.php
+++ b/app/Http/Middleware/EnsureHasPermission.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Services\PermissionService;
+
+class EnsureHasPermission
+{
+    public function __construct(private PermissionService $service)
+    {
+    }
+
+    public function handle(Request $request, Closure $next, string $action, ?string $viewPath = null)
+    {
+        $viewPath = $viewPath ?? '/' . ltrim($request->path(), '/');
+        $user = Auth::user();
+
+        if (!$user || !$this->service->canDo($user, $action, $viewPath)) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Moduleview.php
+++ b/app/Models/Moduleview.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Moduleview extends Model
+{
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $table = 'moduleviews';
+
+    protected $fillable = [
+        'module_id',
+        'menu',
+        'submenu',
+        'view_path',
+        'status',
+        'order_num',
+        'icon',
+    ];
+}

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Permission extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'action',
+        'moduleview_id',
+        'name',
+        'description',
+    ];
+
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, 'rolepermissions')
+            ->withPivot('scope', 'assigned_at')
+            ->withTimestamps();
+    }
+
+    public function moduleview(): BelongsTo
+    {
+        return $this->belongsTo(Moduleview::class, 'moduleview_id');
+    }
+}

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -30,4 +30,11 @@ class Role extends Model
         'user_count'  => 'integer',
         'created_at'  => 'datetime',
     ];
+
+    public function permissions()
+    {
+        return $this->belongsToMany(Permission::class, 'rolepermissions')
+            ->withPivot('scope', 'assigned_at')
+            ->withTimestamps();
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -119,4 +119,9 @@ class User extends Authenticatable
     {
         return $this->hasMany(Commission::class, 'user_id');
     }
+
+    public function roles()
+    {
+        return $this->belongsToMany(Role::class, 'userroles')->withTimestamps();
+    }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,12 +4,15 @@ namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate;
 use App\Models\Invoice;
 use App\Models\Payment;
 use App\Models\PaymentPlan;
 use App\Policies\InvoicePolicy;
 use App\Policies\PaymentPolicy;
 use App\Policies\PaymentPlanPolicy;
+use App\Models\User;
+use App\Services\PermissionService;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -29,6 +32,10 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        $this->registerPolicies();
+
+        Gate::define('do-action-on-path', function (User $user, string $action, string $path) {
+            return app(PermissionService::class)->canDo($user, $action, $path);
+        });
     }
 }

--- a/app/Services/PermissionService.php
+++ b/app/Services/PermissionService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+
+class PermissionService
+{
+    public function canDo(User $user, string $action, string $viewPath): bool
+    {
+        $target = $action.':'.$viewPath;
+        $roles = $user->roles()->with('permissions')->get();
+
+        foreach ($roles as $role) {
+            foreach ($role->permissions as $permission) {
+                if ($this->matches($permission->name, $target)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function matches(string $permissionName, string $target): bool
+    {
+        [$permAction, $permPath] = explode(':', $permissionName, 2);
+        [$targetAction, $targetPath] = explode(':', $target, 2);
+        if ($permAction !== $targetAction) {
+            return false;
+        }
+
+        if (str_ends_with($permPath, '%')) {
+            $prefix = rtrim($permPath, '%');
+            return str_starts_with($targetPath, $prefix);
+        }
+
+        return $permPath === $targetPath;
+    }
+}

--- a/database/migrations/2025_06_25_160510_create_permissions_table.php
+++ b/database/migrations/2025_06_25_160510_create_permissions_table.php
@@ -13,17 +13,19 @@ return new class extends Migration
     {
         Schema::create('permissions', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('module', 50)->nullable();
-            $table->string('section', 50)->nullable();
-            $table->string('resource', 50)->nullable();
-            $table->string('action', 50)->nullable();
-            $table->enum('effect', ['allow', 'deny'])->nullable();
-            $table->text('description')->nullable();
-            $table->string('route_path')->nullable();
-            $table->string('file_name', 100)->nullable();
-            $table->integer('object_id')->nullable();
-            $table->boolean('is_enabled')->nullable()->default(true);
-            $table->enum('level', ['view', 'create', 'edit', 'delete', 'export'])->nullable();
+            $table->enum('action', ['view', 'create', 'edit', 'delete', 'export']);
+            $table->unsignedInteger('moduleview_id')->nullable();
+            $table->string('name')->unique();
+            $table->string('description')->nullable();
+            $table->timestamps();
+
+            $table->index('action');
+            $table->index('moduleview_id');
+            $table->foreign('moduleview_id')
+                ->references('id')
+                ->on('moduleviews')
+                ->onUpdate('cascade')
+                ->onDelete('cascade');
         });
     }
 

--- a/database/migrations/2025_08_11_000000_alter_rolepermissions_add_fks_unique.php
+++ b/database/migrations/2025_08_11_000000_alter_rolepermissions_add_fks_unique.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE rolepermissions DROP CONSTRAINT IF EXISTS rolepermissions_role_id_foreign');
+        DB::statement('ALTER TABLE rolepermissions DROP CONSTRAINT IF EXISTS rolepermissions_permission_id_foreign');
+
+        Schema::table('rolepermissions', function (Blueprint $table) {
+            $table->foreign('role_id')
+                ->references('id')
+                ->on('roles')
+                ->onUpdate('cascade')
+                ->onDelete('cascade');
+            $table->foreign('permission_id')
+                ->references('id')
+                ->on('permissions')
+                ->onUpdate('cascade')
+                ->onDelete('cascade');
+            $table->unique(['role_id', 'permission_id', 'scope']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('rolepermissions', function (Blueprint $table) {
+            $table->dropUnique(['role_id', 'permission_id', 'scope']);
+        });
+
+        DB::statement('ALTER TABLE rolepermissions DROP CONSTRAINT IF EXISTS rolepermissions_role_id_foreign');
+        DB::statement('ALTER TABLE rolepermissions DROP CONSTRAINT IF EXISTS rolepermissions_permission_id_foreign');
+    }
+};

--- a/database/seeders/PermissionsSeeder.php
+++ b/database/seeders/PermissionsSeeder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class PermissionsSeeder extends Seeder
+{
+    private const ACTIONS = ['view', 'create', 'edit', 'delete', 'export'];
+
+    public function run(): void
+    {
+        $moduleviews = DB::table('moduleviews')->get(['id', 'view_path', 'menu', 'submenu']);
+        $now = now();
+        $records = [];
+
+        foreach ($moduleviews as $mv) {
+            foreach (self::ACTIONS as $action) {
+                $name = $action . ':' . $mv->view_path;
+                $records[] = [
+                    'action' => $action,
+                    'moduleview_id' => $mv->id,
+                    'name' => $name,
+                    'description' => sprintf('%s sobre %s/%s (%s)', $action, $mv->menu, $mv->submenu, $mv->view_path),
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ];
+            }
+        }
+
+        if (!empty($records)) {
+            DB::table('permissions')->upsert($records, ['name']);
+        }
+    }
+}

--- a/database/seeders/RolePermissionsSeeder.php
+++ b/database/seeders/RolePermissionsSeeder.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use App\Models\Role;
+use App\Models\Permission;
+
+class RolePermissionsSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $mapping = [
+            'Administrador' => '*',
+            'Docente' => [
+                '/docente%' => ['view','create','edit','export'],
+                '/academico%' => ['view','create','edit','export'],
+            ],
+            'Estudiante' => [
+                '/estudiantes%' => ['view'],
+            ],
+            'Administrativo' => [
+                '/admin%' => ['view','create','edit','export'],
+                '/inscripcion%' => ['view','create','edit','export'],
+            ],
+            'Finanzas' => [
+                '/finanzas%' => ['view','create','edit','delete','export'],
+            ],
+            'Seguridad' => [
+                '/seguridad%' => ['view','create','edit','delete','export'],
+            ],
+            'Asesor' => [
+                '/gestion%' => ['view','create','edit','export'],
+                '/captura%' => ['view','create','edit','export'],
+                '/leads-asignados%' => ['view','create','edit','export'],
+                '/seguimiento%' => ['view','create','edit','export'],
+                '/importar-leads%' => ['view','create','edit','export'],
+                '/correos%' => ['view','create','edit','export'],
+                '/calendario%' => ['view','create','edit','export'],
+            ],
+            'Marketing' => [
+                '/admin/plantillas-mailing%' => ['view','export'],
+                '/finanzas/reportes%' => ['view','export'],
+                '/admin%' => ['view','export'],
+            ],
+        ];
+
+        foreach ($mapping as $roleName => $rules) {
+            $role = Role::where('name', $roleName)->first();
+            if (!$role) {
+                continue;
+            }
+
+            $permissionIds = [];
+            if ($rules === '*') {
+                $permissionIds = Permission::pluck('id')->all();
+            } else {
+                foreach ($rules as $prefix => $actions) {
+                    foreach ($actions as $action) {
+                        $ids = Permission::where('name', 'like', $action.':'.$prefix)->pluck('id')->all();
+                        $permissionIds = array_merge($permissionIds, $ids);
+                    }
+                }
+                $permissionIds = array_unique($permissionIds);
+            }
+
+            foreach ($permissionIds as $pid) {
+                DB::table('rolepermissions')->upsert([
+                    'role_id' => $role->id,
+                    'permission_id' => $pid,
+                    'scope' => 'global',
+                    'assigned_at' => now(),
+                ], ['role_id','permission_id','scope'], ['assigned_at']);
+            }
+        }
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -28,5 +28,6 @@
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
+        <env name="MOODLE_TOKEN" value="testing"/>
     </php>
 </phpunit>

--- a/tests/Feature/PermissionsTest.php
+++ b/tests/Feature/PermissionsTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Tests\TestCase;
+use App\Models\Role;
+use App\Models\User;
+use App\Models\Permission;
+use App\Models\Moduleview;
+use App\Services\PermissionService;
+
+class PermissionsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropAllTables();
+
+        Schema::create('modules', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        Schema::create('moduleviews', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('module_id');
+            $table->string('menu')->nullable();
+            $table->string('submenu')->nullable();
+            $table->string('view_path');
+        });
+
+        Schema::create('roles', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+        });
+
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('action');
+            $table->unsignedInteger('moduleview_id')->nullable();
+            $table->string('name')->unique();
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('rolepermissions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('role_id');
+            $table->unsignedInteger('permission_id');
+            $table->string('scope')->nullable();
+            $table->timestamp('assigned_at')->nullable();
+            $table->unique(['role_id','permission_id','scope']);
+            $table->timestamps();
+        });
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email');
+            $table->string('password');
+            $table->timestamp('deleted_at')->nullable();
+        });
+
+        Schema::create('userroles', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id');
+            $table->unsignedInteger('role_id');
+            $table->timestamp('assigned_at')->nullable();
+            $table->timestamps();
+        });
+
+        // Seed roles
+        $roles = ['Administrador','Finanzas','Estudiante'];
+        foreach ($roles as $name) {
+            DB::table('roles')->insert(['name'=>$name]);
+        }
+
+        $moduleId = DB::table('modules')->insertGetId(['name'=>'Test']);
+        Moduleview::create(['module_id'=>$moduleId,'menu'=>'Fin','submenu'=>'Pagos','view_path'=>'/finanzas/gestion-pagos']);
+        Moduleview::create(['module_id'=>$moduleId,'menu'=>'Est','submenu'=>'Ficha','view_path'=>'/estudiantes/ficha']);
+        Moduleview::create(['module_id'=>$moduleId,'menu'=>'Seg','submenu'=>'Logs','view_path'=>'/seguridad/logs']);
+
+        (new \Database\Seeders\PermissionsSeeder())->run();
+        (new \Database\Seeders\RolePermissionsSeeder())->run();
+
+        $adminId = DB::table('users')->insertGetId(['name'=>'Admin','email'=>'admin@test.com','password'=>'x']);
+        $finId = DB::table('users')->insertGetId(['name'=>'Fin','email'=>'fin@test.com','password'=>'x']);
+        $estId = DB::table('users')->insertGetId(['name'=>'Est','email'=>'est@test.com','password'=>'x']);
+
+        $adminRole = Role::where('name','Administrador')->first();
+        $finRole = Role::where('name','Finanzas')->first();
+        $estRole = Role::where('name','Estudiante')->first();
+
+        DB::table('userroles')->insert(['user_id'=>$adminId,'role_id'=>$adminRole->id,'assigned_at'=>now()]);
+        DB::table('userroles')->insert(['user_id'=>$finId,'role_id'=>$finRole->id,'assigned_at'=>now()]);
+        DB::table('userroles')->insert(['user_id'=>$estId,'role_id'=>$estRole->id,'assigned_at'=>now()]);
+    }
+
+    public function test_seeder_creates_permissions(): void
+    {
+        $this->assertEquals(5 * Moduleview::count(), Permission::count());
+    }
+
+    public function test_permission_service_respects_roles(): void
+    {
+        $service = app(PermissionService::class);
+        $finUser = User::where('email', 'fin@test.com')->first();
+        $estUser = User::where('email', 'est@test.com')->first();
+        $admin = User::where('email', 'admin@test.com')->first();
+
+        $this->assertTrue($service->canDo($finUser, 'edit', '/finanzas/gestion-pagos'));
+        $this->assertFalse($service->canDo($estUser, 'edit', '/finanzas/gestion-pagos'));
+        $this->assertTrue($service->canDo($admin, 'delete', '/seguridad/logs'));
+    }
+
+    public function test_gate_authorization(): void
+    {
+        $finUser = User::where('email', 'fin@test.com')->first();
+        $estUser = User::where('email', 'est@test.com')->first();
+
+        $this->assertTrue(Gate::forUser($finUser)->allows('do-action-on-path', ['edit', '/finanzas/gestion-pagos']));
+        $this->assertTrue(Gate::forUser($estUser)->denies('do-action-on-path', ['edit', '/finanzas/gestion-pagos']));
+    }
+
+    public function test_permissions_sync_is_idempotent(): void
+    {
+        $count = Permission::count();
+        Artisan::call('permissions:sync');
+        $this->assertEquals($count, Permission::count());
+    }
+}


### PR DESCRIPTION
## Summary
- create permissions table linked to module views with cascade foreign key
- seed CRUD permissions and map to roles with scope control
- add PermissionService, gate, middleware and sync command
- cover permission checks with feature tests
- harden rolepermissions migration by dropping nonexistent FKs conditionally

## Testing
- `php artisan migrate --force` *(fails: Failed opening required '.../HTMLPurifier.composer.php')*
- `php vendor/bin/phpunit tests/Feature/PermissionsTest.php` *(fails: Failed opening required '.../HTMLPurifier.composer.php')*

------
https://chatgpt.com/codex/tasks/task_e_6899eb3db744832894ea33e6c8f2c648